### PR TITLE
Digest auth: fix merge conflicts with master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ __pycache__/
 htmlcov/
 site/
 *.egg-info/
-venv/
+venv*/
 .nox
+.python-version

--- a/httpx/client.py
+++ b/httpx/client.py
@@ -23,12 +23,10 @@ from .dispatch.connection_pool import ConnectionPool
 from .dispatch.threaded import ThreadedDispatcher
 from .dispatch.wsgi import WSGIDispatch
 from .exceptions import HTTPError, InvalidURL
-from .middleware import (
-    BaseMiddleware,
-    BasicAuthMiddleware,
-    CustomAuthMiddleware,
-    RedirectMiddleware,
-)
+from .middleware.base import BaseMiddleware
+from .middleware.basic_auth import BasicAuthMiddleware
+from .middleware.custom_auth import CustomAuthMiddleware
+from .middleware.redirect import RedirectMiddleware
 from .models import (
     URL,
     AsyncRequest,

--- a/httpx/concurrency/base.py
+++ b/httpx/concurrency/base.py
@@ -88,6 +88,9 @@ class BaseEvent:
     def is_set(self) -> bool:
         raise NotImplementedError()  # pragma: no cover
 
+    def clear(self) -> None:
+        raise NotImplementedError()  # pragma: no cover
+
     async def wait(self) -> None:
         raise NotImplementedError()  # pragma: no cover
 

--- a/httpx/dispatch/http2.py
+++ b/httpx/dispatch/http2.py
@@ -4,7 +4,7 @@ import typing
 import h2.connection
 import h2.events
 
-from ..concurrency.base import BaseStream, ConcurrencyBackend, TimeoutFlag
+from ..concurrency.base import BaseStream, ConcurrencyBackend, TimeoutFlag, BaseEvent
 from ..config import TimeoutConfig, TimeoutTypes
 from ..models import AsyncRequest, AsyncResponse
 from ..utils import get_logger
@@ -28,6 +28,7 @@ class HTTP2Connection:
         self.events = {}  # type: typing.Dict[int, typing.List[h2.events.Event]]
         self.timeout_flags = {}  # type: typing.Dict[int, TimeoutFlag]
         self.initialized = False
+        self.window_update_received = {}  # type: typing.Dict[int, BaseEvent]
 
     async def send(
         self, request: AsyncRequest, timeout: TimeoutTypes = None
@@ -42,6 +43,7 @@ class HTTP2Connection:
 
         self.events[stream_id] = []
         self.timeout_flags[stream_id] = TimeoutFlag()
+        self.window_update_received[stream_id] = self.backend.create_event()
 
         task, args = self.send_request_data, [stream_id, request.stream(), timeout]
         async with self.backend.background_manager(task, *args):
@@ -108,18 +110,27 @@ class HTTP2Connection:
     async def send_data(
         self, stream_id: int, data: bytes, timeout: TimeoutConfig = None
     ) -> None:
-        flow_control = self.h2_state.local_flow_control_window(stream_id)
-        chunk_size = min(len(data), flow_control)
-        for idx in range(0, len(data), chunk_size):
-            chunk = data[idx : idx + chunk_size]
-
-            logger.debug(
-                f"send_data stream_id={stream_id} data=Data(<{len(chunk)} bytes>)"
+        while data:
+            # The data will be divided into frames to send based on the flow control
+            # window and the maximum frame size. Because the flow control window
+            # can decrease in size, even possibly to zero, this will loop until all the
+            # data is sent. In http2 specification:
+            # https://tools.ietf.org/html/rfc7540#section-6.9
+            flow_control = self.h2_state.local_flow_control_window(stream_id)
+            chunk_size = min(
+                len(data), flow_control, self.h2_state.max_outbound_frame_size
             )
-
-            self.h2_state.send_data(stream_id, chunk)
-            data_to_send = self.h2_state.data_to_send()
-            await self.stream.write(data_to_send, timeout)
+            if chunk_size == 0:
+                # this means that the flow control window is 0 (either for the stream
+                # or the connection one), and no data can be sent until the flow control
+                # window is updated.
+                await self.window_update_received[stream_id].wait()
+                self.window_update_received[stream_id].clear()
+            else:
+                chunk, data = data[:chunk_size], data[chunk_size:]
+                self.h2_state.send_data(stream_id, chunk)
+                data_to_send = self.h2_state.data_to_send()
+                await self.stream.write(data_to_send, timeout)
 
     async def end_stream(self, stream_id: int, timeout: TimeoutConfig = None) -> None:
         logger.debug(f"end_stream stream_id={stream_id}")
@@ -148,7 +159,8 @@ class HTTP2Connection:
                 status_code = int(v.decode("ascii", errors="ignore"))
             elif not k.startswith(b":"):
                 headers.append((k, v))
-        return status_code, headers
+
+        return (status_code, headers)
 
     async def body_iter(
         self, stream_id: int, timeout: TimeoutConfig = None
@@ -156,7 +168,9 @@ class HTTP2Connection:
         while True:
             event = await self.receive_event(stream_id, timeout)
             if isinstance(event, h2.events.DataReceived):
-                self.h2_state.acknowledge_received_data(len(event.data), stream_id)
+                self.h2_state.acknowledge_received_data(
+                    event.flow_controlled_length, stream_id
+                )
                 yield event.data
             elif isinstance(event, (h2.events.StreamEnded, h2.events.StreamReset)):
                 break
@@ -173,6 +187,19 @@ class HTTP2Connection:
                 logger.debug(
                     f"receive_event stream_id={event_stream_id} event={event!r}"
                 )
+                if isinstance(event, h2.events.WindowUpdated):
+                    if event_stream_id == 0:
+                        for window_update_event in self.window_update_received.values():
+                            window_update_event.set()
+                    else:
+                        try:
+                            self.window_update_received[event_stream_id].set()
+                        except KeyError:
+                            # the window_update_received dictionary is only relevant
+                            # when sending data, which should never raise a KeyError
+                            # here.
+                            pass
+
                 if event_stream_id:
                     self.events[event.stream_id].append(event)
 
@@ -184,6 +211,7 @@ class HTTP2Connection:
     async def response_closed(self, stream_id: int) -> None:
         del self.events[stream_id]
         del self.timeout_flags[stream_id]
+        del self.window_update_received[stream_id]
 
         if not self.events and self.on_release is not None:
             await self.on_release()

--- a/httpx/dispatch/http2.py
+++ b/httpx/dispatch/http2.py
@@ -4,7 +4,7 @@ import typing
 import h2.connection
 import h2.events
 
-from ..concurrency.base import BaseStream, ConcurrencyBackend, TimeoutFlag, BaseEvent
+from ..concurrency.base import BaseEvent, BaseStream, ConcurrencyBackend, TimeoutFlag
 from ..config import TimeoutConfig, TimeoutTypes
 from ..models import AsyncRequest, AsyncResponse
 from ..utils import get_logger

--- a/httpx/middleware.py
+++ b/httpx/middleware.py
@@ -147,15 +147,14 @@ class RedirectMiddleware(BaseMiddleware):
         if url.origin != request.url.origin:
             # Strip Authorization headers when responses are redirected away from
             # the origin.
-            del headers["Authorization"]
+            headers.pop("Authorization", None)
             headers["Host"] = url.authority
 
         if method != request.method and method == "GET":
             # If we've switch to a 'GET' request, then strip any headers which
             # are only relevant to the request body.
-            del headers["Content-Length"]
-            del headers["Transfer-Encoding"]
-
+            headers.pop("Content-Length", None)
+            headers.pop("Transfer-Encoding", None)
         return headers
 
     def redirect_content(self, request: AsyncRequest, method: str) -> bytes:

--- a/httpx/middleware/base.py
+++ b/httpx/middleware/base.py
@@ -1,0 +1,10 @@
+import typing
+
+from ..models import AsyncRequest, AsyncResponse
+
+
+class BaseMiddleware:
+    async def __call__(
+        self, request: AsyncRequest, get_response: typing.Callable
+    ) -> AsyncResponse:
+        raise NotImplementedError  # pragma: no cover

--- a/httpx/middleware/basic_auth.py
+++ b/httpx/middleware/basic_auth.py
@@ -1,0 +1,27 @@
+import typing
+from base64 import b64encode
+
+from ..models import AsyncRequest, AsyncResponse
+from ..utils import to_bytes
+from .base import BaseMiddleware
+
+
+class BasicAuthMiddleware(BaseMiddleware):
+    def __init__(
+        self, username: typing.Union[str, bytes], password: typing.Union[str, bytes]
+    ):
+        self.authorization_header = build_basic_auth_header(username, password)
+
+    async def __call__(
+        self, request: AsyncRequest, get_response: typing.Callable
+    ) -> AsyncResponse:
+        request.headers["Authorization"] = self.authorization_header
+        return await get_response(request)
+
+
+def build_basic_auth_header(
+    username: typing.Union[str, bytes], password: typing.Union[str, bytes]
+) -> str:
+    userpass = b":".join((to_bytes(username), to_bytes(password)))
+    token = b64encode(userpass).decode().strip()
+    return f"Basic {token}"

--- a/httpx/middleware/custom_auth.py
+++ b/httpx/middleware/custom_auth.py
@@ -1,0 +1,15 @@
+import typing
+
+from ..models import AsyncRequest, AsyncResponse
+from .base import BaseMiddleware
+
+
+class CustomAuthMiddleware(BaseMiddleware):
+    def __init__(self, auth: typing.Callable[[AsyncRequest], AsyncRequest]):
+        self.auth = auth
+
+    async def __call__(
+        self, request: AsyncRequest, get_response: typing.Callable
+    ) -> AsyncResponse:
+        request = self.auth(request)
+        return await get_response(request)

--- a/httpx/middleware/redirect.py
+++ b/httpx/middleware/redirect.py
@@ -1,51 +1,11 @@
 import functools
 import typing
-from base64 import b64encode
 
-from .config import DEFAULT_MAX_REDIRECTS
-from .exceptions import RedirectBodyUnavailable, RedirectLoop, TooManyRedirects
-from .models import URL, AsyncRequest, AsyncResponse, Cookies, Headers
-from .status_codes import codes
-
-
-class BaseMiddleware:
-    async def __call__(
-        self, request: AsyncRequest, get_response: typing.Callable
-    ) -> AsyncResponse:
-        raise NotImplementedError  # pragma: no cover
-
-
-class BasicAuthMiddleware(BaseMiddleware):
-    def __init__(
-        self, username: typing.Union[str, bytes], password: typing.Union[str, bytes]
-    ):
-        if isinstance(username, str):
-            username = username.encode("latin1")
-
-        if isinstance(password, str):
-            password = password.encode("latin1")
-
-        userpass = b":".join((username, password))
-        token = b64encode(userpass).decode().strip()
-
-        self.authorization_header = f"Basic {token}"
-
-    async def __call__(
-        self, request: AsyncRequest, get_response: typing.Callable
-    ) -> AsyncResponse:
-        request.headers["Authorization"] = self.authorization_header
-        return await get_response(request)
-
-
-class CustomAuthMiddleware(BaseMiddleware):
-    def __init__(self, auth: typing.Callable[[AsyncRequest], AsyncRequest]):
-        self.auth = auth
-
-    async def __call__(
-        self, request: AsyncRequest, get_response: typing.Callable
-    ) -> AsyncResponse:
-        request = self.auth(request)
-        return await get_response(request)
+from ..config import DEFAULT_MAX_REDIRECTS
+from ..exceptions import RedirectBodyUnavailable, RedirectLoop, TooManyRedirects
+from ..models import URL, AsyncRequest, AsyncResponse, Cookies, Headers
+from ..status_codes import codes
+from .base import BaseMiddleware
 
 
 class RedirectMiddleware(BaseMiddleware):

--- a/httpx/models.py
+++ b/httpx/models.py
@@ -473,6 +473,8 @@ class Headers(typing.MutableMapping[str, str]):
         for idx, (item_key, _) in enumerate(self._list):
             if item_key == del_key:
                 pop_indexes.append(idx)
+        if not pop_indexes:
+            raise KeyError(key)
 
         for idx in reversed(pop_indexes):
             del self._list[idx]
@@ -624,7 +626,6 @@ class AsyncRequest(BaseRequest):
             assert hasattr(data, "__aiter__")
             self.is_streaming = True
             self.content_aiter = data
-
         self.prepare()
 
     async def read(self) -> bytes:

--- a/httpx/utils.py
+++ b/httpx/utils.py
@@ -169,3 +169,7 @@ def get_logger(name: str) -> logging.Logger:
             logger.addHandler(handler)
 
     return logging.getLogger(name)
+
+
+def to_bytes(value: typing.Union[str, bytes], encoding: str = "utf-8") -> bytes:
+    return value.encode(encoding) if isinstance(value, str) else value

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -14,3 +14,6 @@ pytest-asyncio
 pytest-cov
 trustme
 uvicorn
+
+# https://github.com/MagicStack/uvloop/issues/266
+uvloop<0.13; sys_platform != 'win32' and sys_platform != 'cygwin' and platform_python_implementation != 'pypy'

--- a/tests/client/test_headers.py
+++ b/tests/client/test_headers.py
@@ -2,6 +2,8 @@
 
 import json
 
+import pytest
+
 from httpx import (
     AsyncDispatcher,
     AsyncRequest,
@@ -11,6 +13,7 @@ from httpx import (
     TimeoutTypes,
     VerifyTypes,
     __version__,
+    models,
 )
 
 
@@ -122,3 +125,9 @@ def test_header_update():
             "user-agent": "python-myclient/0.2.1",
         }
     }
+
+
+def test_header_does_not_exist():
+    headers = models.Headers({"foo": "bar"})
+    with pytest.raises(KeyError):
+        del headers["baz"]

--- a/tests/dispatch/test_http2.py
+++ b/tests/dispatch/test_http2.py
@@ -65,6 +65,34 @@ async def test_async_http2_post_request(backend):
     }
 
 
+def test_http2_large_post_request():
+    backend = MockHTTP2Backend(app=app)
+
+    data = b"a" * 100000
+    with Client(backend=backend) as client:
+        response = client.post("http://example.org", data=data)
+    assert response.status_code == 200
+    assert json.loads(response.content) == {
+        "method": "POST",
+        "path": "/",
+        "body": data.decode(),
+    }
+
+
+async def test_async_http2_large_post_request(backend):
+    backend = MockHTTP2Backend(app=app, backend=backend)
+
+    data = b"a" * 100000
+    async with AsyncClient(backend=backend) as client:
+        response = await client.post("http://example.org", data=data)
+    assert response.status_code == 200
+    assert json.loads(response.content) == {
+        "method": "POST",
+        "path": "/",
+        "body": data.decode(),
+    }
+
+
 def test_http2_multiple_requests():
     backend = MockHTTP2Backend(app=app)
 


### PR DESCRIPTION
@yeraydiazdiaz I merged the changes from master back into your branch and fixed the conflicts after the middleware refactor (https://github.com/encode/httpx/pull/325), but since this is in your fork I'm opening a PR here for you to incorporate the changes. :-)

I also reverted to `DigestAuthMiddleware` but made sure that it is *exported* as `DigestAuth`. Let me know if that sounds acceptable.